### PR TITLE
adding global filter, closes #11

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,7 @@ store.suggest();
     * suggestionsProcessor
 * facets
     * facetMode
+    * globalFilter
     * facets
 * parameters 
     * input
@@ -323,6 +324,9 @@ setFacetRange(fieldName, lowerBound, upperBound);
 toggleCheckboxFacet(fieldName, value);
 // reset all selected values/ranged for all facets
 clearFacetsSelections();
+// set a global filter that will be AND'd with the filters produced by your facets
+// this will set a static filter that will always filter results to english
+setGlobalFilter("language eq 'english'");
 ```
 
 ## Extensibility

--- a/src/AzSearchStore.ts
+++ b/src/AzSearchStore.ts
@@ -96,6 +96,9 @@ export class AzSearchStore {
     public clearFacetsSelections() {
         this.store.dispatch(facetsActions.clearFacetsSelections());
     }
+    public setGlobalFilter(filter: string) {
+        this.store.dispatch(facetsActions.setGlobalFilter(filter));
+    }
 
     // extensibility
 

--- a/src/actions/__tests__/facetsActions_tests.ts
+++ b/src/actions/__tests__/facetsActions_tests.ts
@@ -97,4 +97,12 @@ describe("actions/facets", () => {
             type: "CLEAR_FACETS_SELECTIONS",
         });
     });
+    it("should create action to set a global filter", () => {
+        expect(
+            facetsActions.setGlobalFilter("foo lt 5")
+        ).toEqual({
+            type: "SET_GLOBAL_FILTER",
+            filter: "foo lt 5"
+        });
+    });
 });

--- a/src/actions/facetsActions.ts
+++ b/src/actions/facetsActions.ts
@@ -8,7 +8,8 @@ export type FacetsAction =
     SetFacetModeAction |
     SetFacetsValuesAction |
     UpdateFacetValuesAction |
-    ClearFacetsSelectionsAction;
+    ClearFacetsSelectionsAction |
+    SetGlobalFilterAction;
 export type ClearFacetsSelectionsAction = {
     type: "CLEAR_FACETS_SELECTIONS",
 };
@@ -48,6 +49,10 @@ export type SetFacetRangeAction = {
     key: string,
     lowerBound: number | Date,
     upperBound: number | Date
+};
+export type SetGlobalFilterAction = {
+    type: "SET_GLOBAL_FILTER",
+    filter: string
 };
 
 export const setFacetsValues = (facets: { [key: string]: Store.FacetResult[] }): FacetsAction => ({
@@ -95,3 +100,5 @@ export const setFacetRange = (key: string, lowerBound: number | Date, upperBound
 });
 
 export const clearFacetsSelections = (): FacetsAction => ({ type: "CLEAR_FACETS_SELECTIONS" });
+
+export const setGlobalFilter = (filter: string): FacetsAction => ({ type: "SET_GLOBAL_FILTER", filter });

--- a/src/reducers/__tests__/facets_test.ts
+++ b/src/reducers/__tests__/facets_test.ts
@@ -32,6 +32,7 @@ describe("reducers/facets", () => {
             reducer(facets.initialState, facetsAction.setFacetMode("advanced"))
         ).toEqual({
             facets: {},
+            globalFilter: "",
             facetMode: "advanced"
         });
     });
@@ -56,6 +57,7 @@ describe("reducers/facets", () => {
             facets: {
                 "foo": expectedFacet
             },
+            globalFilter: "",
             facetMode: "simple"
         });
     });
@@ -80,6 +82,7 @@ describe("reducers/facets", () => {
             facets: {
                 "foo": expectedFacet
             },
+            globalFilter: "",
             facetMode: "simple"
         });
     });
@@ -100,6 +103,7 @@ describe("reducers/facets", () => {
             facets: {
                 "foo": expectedFacet
             },
+            globalFilter: "",
             facetMode: "simple"
         });
     });
@@ -120,6 +124,7 @@ describe("reducers/facets", () => {
             facets: {
                 "foo": expectedFacet
             },
+            globalFilter: "",
             facetMode: "simple"
         });
     });
@@ -167,10 +172,12 @@ describe("reducers/facets", () => {
             facetClause: "foo,values:5|7"
         };
         const initialFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: { foo: initialFacet, dummy: dummyFacet }
         };
         const expectedFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: { foo: expectedFacet, dummy: dummyFacet }
         };
@@ -222,10 +229,12 @@ describe("reducers/facets", () => {
             facetClause: "foo,values:1970-01-01T00:00:01.999Z|1970-01-01T00:00:02.015Z"
         };
         const initialFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: { foo: initialFacet, dummy: dummyFacet }
         };
         const expectedFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: { foo: expectedFacet, dummy: dummyFacet }
         };
@@ -319,14 +328,17 @@ describe("reducers/facets", () => {
             facetClause: "foo,count:5,sort:count"
         };
         const initialFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: { foo: initialFacet, dummy: dummyFacet }
         };
         const firstToggleExpectedFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: { foo: firstToggleFacet, dummy: dummyFacet }
         };
         const secondToggleExpectedFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: { foo: secondToggleFacet, dummy: dummyFacet }
         };
@@ -403,10 +415,12 @@ describe("reducers/facets", () => {
         };
 
         const initialFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: { foo: initialFacet, dummy: dummyFacet }
         };
         const firstToggleExpectedFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: { foo: firstToggleFacet, dummy: dummyFacet }
         };
@@ -488,6 +502,7 @@ describe("reducers/facets", () => {
         };
 
         const initialFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: {
                 "foo": checkFacet,
@@ -496,6 +511,7 @@ describe("reducers/facets", () => {
         };
 
         const expectedFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: {
                 "foo": expectedCheckFacet,
@@ -625,6 +641,7 @@ describe("reducers/facets", () => {
         };
 
         const initialFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: {
                 "foo": checkFacet,
@@ -634,6 +651,7 @@ describe("reducers/facets", () => {
         };
 
         const expectedFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: {
                 "foo": expectedCheckFacet,
@@ -765,6 +783,7 @@ describe("reducers/facets", () => {
         };
 
         const initialFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: {
                 "foo": checkFacetSelected,
@@ -773,6 +792,7 @@ describe("reducers/facets", () => {
         };
 
         const expectedFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: {
                 "foo": expectedCheckFacetSelected,
@@ -854,6 +874,7 @@ describe("reducers/facets", () => {
         };
 
         const initialFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: {
                 "foo": checkFacet
@@ -861,6 +882,7 @@ describe("reducers/facets", () => {
         };
 
         const expectedFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: {
                 "foo": expectedCheckFacet,
@@ -954,6 +976,7 @@ describe("reducers/facets", () => {
         };
 
         const initialFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: {
                 "foo": checkFacet,
@@ -962,6 +985,7 @@ describe("reducers/facets", () => {
         };
 
         const expectedFacets: Store.Facets = {
+            globalFilter: "",
             facetMode: "simple",
             facets: {
                 "foo": expectedCheckFacet,
@@ -971,6 +995,65 @@ describe("reducers/facets", () => {
 
         expect(
             reducer(initialFacets, facetsAction.clearFacetsSelections())
+        ).toEqual(expectedFacets);
+    });
+    it("should set global filter", () => {
+        const checkFacet: Store.CheckboxFacet = {
+            type: "CheckboxFacet",
+            key: "foo",
+            dataType: "string",
+            values: {
+                a: {
+                    value: "a",
+                    count: 5,
+                    selected: true
+                },
+                b: {
+                    value: "b",
+                    count: 5,
+                    selected: false
+                }
+            },
+            count: 5,
+            sort: "count",
+            filterClause: "( foo eq 'a )",
+            facetClause: "foo,count:5,sort:count"
+        };
+        const rangeFacet: Store.RangeFacet = {
+            type: "RangeFacet",
+            key: "bar",
+            dataType: "number",
+            min: 0,
+            max: 10,
+            filterLowerBound: 5,
+            filterUpperBound: 7,
+            lowerBucketCount: 4,
+            middleBucketCount: 5,
+            upperBucketCount: 3,
+            filterClause: "bar ge 5 and bar le 7",
+            facetClause: "bar,values:0|10"
+        };
+
+        const initialFacets: Store.Facets = {
+            globalFilter: "",
+            facetMode: "simple",
+            facets: {
+                "foo": checkFacet,
+                "bar": rangeFacet,
+            }
+        };
+
+        const expectedFacets: Store.Facets = {
+            globalFilter: "buzz lt 6",
+            facetMode: "simple",
+            facets: {
+                "foo": checkFacet,
+                "bar": rangeFacet,
+            }
+        };
+
+        expect(
+            reducer(initialFacets, facetsAction.setGlobalFilter("buzz lt 6"))
         ).toEqual(expectedFacets);
     });
 });

--- a/src/reducers/facets.ts
+++ b/src/reducers/facets.ts
@@ -1,7 +1,8 @@
 import {
     FacetsAction, SetFacetRangeAction, ToggleCheckboxFacetAction,
     AddCheckboxFacetAction, AddRangeFacetAction, SetFacetModeAction,
-    SetFacetsValuesAction, UpdateFacetValuesAction, ClearFacetsSelectionsAction
+    SetFacetsValuesAction, UpdateFacetValuesAction, ClearFacetsSelectionsAction,
+    SetGlobalFilterAction
 }
     from "../actions/facetsActions";
 import { Store } from "../store";
@@ -10,6 +11,7 @@ import { updateObject, updateObjectAtKey } from "./reducerUtils";
 
 export const initialState: Store.Facets = {
     facetMode: "simple",
+    globalFilter: "",
     facets: {}
 };
 
@@ -25,9 +27,14 @@ export function facets(state: Store.Facets = initialState, action: FacetsAction)
         case "SET_FACETS_VALUES": return setFacetsValues(state, action);
         case "UPDATE_FACETS_VALUES": return updateFacetsValues(state, action);
         case "CLEAR_FACETS_SELECTIONS": return clearFacetsSelections(state, action);
+        case "SET_GLOBAL_FILTER": return setGlobalFilter(state, action);
         default:
             return state;
     }
+}
+
+function setGlobalFilter(state: Store.Facets, action: SetGlobalFilterAction): Store.Facets {
+    return updateObject(state, { globalFilter: action.filter });
 }
 
 function clearFacetsSelections(state: Store.Facets, action: ClearFacetsSelectionsAction): Store.Facets {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -148,6 +148,7 @@ export namespace Store {
 
     export type Facets = {
         facetMode: FacetMode,
+        globalFilter: string,
         facets: { [key: string]: Facet }
     };
 

--- a/src/utils/__tests__/uriHelper_tests.ts
+++ b/src/utils/__tests__/uriHelper_tests.ts
@@ -54,11 +54,13 @@ const parameterInitialState: Store.Parameters = {
 };
 
 const initFacets: Store.Facets = {
+    globalFilter: "",
     facetMode: "simple",
     facets: {}
 };
 
 const testFacets: Store.Facets = {
+    globalFilter: "",
     facetMode: "simple",
     facets: {
         foo: {
@@ -89,6 +91,49 @@ const testFacets: Store.Facets = {
 };
 
 const filteredFacets: Store.Facets = {
+    globalFilter: "",
+    facetMode: "simple",
+    facets: {
+        foo: {
+            type: "RangeFacet",
+            dataType: "number",
+            key: "foo",
+            min: 0,
+            max: 10,
+            filterLowerBound: 5,
+            filterUpperBound: 7,
+            lowerBucketCount: 0,
+            middleBucketCount: 0,
+            upperBucketCount: 0,
+            filterClause: "foo ge 5 and foo le 7",
+            facetClause: "foo,values:0|10"
+        },
+        bar: {
+            type: "CheckboxFacet",
+            key: "bar",
+            dataType: "string",
+            values: {
+                a: {
+                    value: "a",
+                    count: 5,
+                    selected: true
+                },
+                b: {
+                    value: "b",
+                    count: 5,
+                    selected: false
+                }
+            },
+            count: 5,
+            sort: "count",
+            filterClause: "(bar eq 'a')",
+            facetClause: "bar,count:5,sort:count"
+        }
+    }
+};
+
+const filteredFacetsWithGlobalFilter: Store.Facets = {
+    globalFilter: "buzz lt 5",
     facetMode: "simple",
     facets: {
         foo: {
@@ -189,6 +234,49 @@ describe("utils/uriHelper", () => {
             "count": true,
             "facets": ["foo,values:0|10", "bar,count:5,sort:count"],
             "filter": "foo ge 5 and foo le 7 and (bar eq \'a\')",
+            "orderby": "foobar",
+            "queryType": "simple",
+            "scoringProfile": "abc",
+            "search": "show me the money",
+            "searchFields": "def",
+            "searchMode": "all",
+            "select": "hij",
+            "skip": 1000,
+            "top": 3,
+            "highlight": "foo",
+            "highlightPreTag": "<em>",
+            "highlightPostTag": "</em>",
+            "scoringParameters": ["mylocation--122.2,44.8"]
+        });
+    });
+    it("should create a suggest uri from test config, and test suggestions parameters", () => {
+        const uriString = uriHelper.buildSuggestionsURI(config, testParameters);
+        const searchURI = URI(uriString);
+        expect(
+            searchURI.valueOf()
+        ).toEqual("https://buzz.search.windows.net/indexes/foo/docs/suggest?api-version=2016-09-01");
+        expect(searchURI.hasQuery("api-version", "2016-09-01")).toBe(true);
+    });
+    it("should create a suggestions post body from test config, and test suggestions parameters", () => {
+        const postBody = uriHelper.buildPostBody(testParameters.suggestionsParameters, testParameters.input, uriHelper.suggestParameterValidator);
+        expect(
+            postBody
+        ).toEqual({
+            top: 5,
+            fuzzy: false,
+            suggesterName: "sg",
+            search: "show me the money"
+        });
+
+    });
+    it("should create a search uri from test config, default searchParameters and custom facets, filters, and a global filter", () => {
+        const postBody = uriHelper.buildPostBody(testParameters.searchParameters, testParameters.input, uriHelper.searchParameterValidator, filteredFacetsWithGlobalFilter);
+        expect(
+            postBody
+        ).toEqual({
+            "count": true,
+            "facets": ["foo,values:0|10", "bar,count:5,sort:count"],
+            "filter": "foo ge 5 and foo le 7 and (bar eq \'a\') and buzz lt 5",
             "orderby": "foobar",
             "queryType": "simple",
             "scoringProfile": "abc",

--- a/src/utils/uriHelper.ts
+++ b/src/utils/uriHelper.ts
@@ -37,6 +37,9 @@ function getFilterClauses(facets: Store.Facets): string {
     let filters = filteredFacets.map((key) => {
         return facets.facets[key].filterClause;
     });
+    if (facets.globalFilter) {
+        filters.push(facets.globalFilter);
+    }
     return filters.join(" and ");
 }
 
@@ -51,7 +54,7 @@ function getFacetClauses(facets: Store.Facets): string[] {
 
 
 export function buildSearchURI(config: Store.Config, parameters: Store.Parameters): string {
-    const {service, index} = config;
+    const { service, index } = config;
     const apiVersion = parameters.searchParameters.apiVersion;
     const uriTemplate = `https://${service}.search.windows.net/indexes/${index}/docs/search?api-version=${apiVersion}`;
     let searchURI = URI(uriTemplate);
@@ -59,7 +62,7 @@ export function buildSearchURI(config: Store.Config, parameters: Store.Parameter
 }
 
 export function buildSuggestionsURI(config: Store.Config, parameters: Store.Parameters): string {
-    const {service, index} = config;
+    const { service, index } = config;
     const apiVersion = parameters.suggestionsParameters.apiVersion;
     const uriTemplate = `https://${service}.search.windows.net/indexes/${index}/docs/suggest?api-version=${apiVersion}`;
     let searchURI = URI(uriTemplate);


### PR DESCRIPTION
Allows users to set a static filter even without any faceting. Good for scenarios where user may want to scope all results to a single language for instance.