### PR TITLE
Fix TS compiler errors

### DIFF
--- a/examples/react_ts/tsconfig.json
+++ b/examples/react_ts/tsconfig.json
@@ -5,9 +5,16 @@
         "noImplicitAny": true,
         "module": "commonjs",
         "target": "es5",
-        "jsx": "react"
+        "jsx": "react",
+        "typeRoots": [
+            "node_modules/@types"
+        ]
     },
-    "include": [
+    "files": [
         "./index.tsx"
+    ],
+    "exclude": [
+        "dist",
+        "node_modules"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,16 @@
         "noImplicitAny": true,
         "module": "commonjs",
         "target": "es5",
-        "jsx": "react"
+        "jsx": "react",
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
     },
-    "include": [
+    "files": [
         "./src/AzSearchStore.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
     ]
 }


### PR DESCRIPTION
This commit update TS build configuration by adding:
- types roots location
- single entry point for TS
- exclusion for node_modules and already build output

Before:

```bash
yarn run tscompile
yarn run v0.19.1
$ tsc 
node_modules/@types/jest/index.d.ts(7,13): error TS2300: Duplicate identifier 'beforeEach'.
node_modules/@types/jest/index.d.ts(9,13): error TS2300: Duplicate identifier 'afterEach'.
../../node_modules/@types/mocha/index.d.ts(33,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'describe' must be of type 'Describe', but here has type 'IContextDefinition'.
../../node_modules/@types/mocha/index.d.ts(34,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'xdescribe' must be of type 'Describe', but here has type 'IContextDefinition'.
../../node_modules/@types/mocha/index.d.ts(39,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'it' must be of type 'It', but here has type 'ITestDefinition'.
../../node_modules/@types/mocha/index.d.ts(40,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'xit' must be of type 'It', but here has type 'ITestDefinition'.
../../node_modules/@types/mocha/index.d.ts(42,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'test' must be of type 'It', but here has type 'ITestDefinition'.
../../node_modules/@types/mocha/index.d.ts(60,18): error TS2300: Duplicate identifier 'beforeEach'.
../../node_modules/@types/mocha/index.d.ts(61,18): error TS2300: Duplicate identifier 'beforeEach'.
../../node_modules/@types/mocha/index.d.ts(62,18): error TS2300: Duplicate identifier 'afterEach'.
../../node_modules/@types/mocha/index.d.ts(63,18): error TS2300: Duplicate identifier 'afterEach'.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After:

```bash
yarn run tscompile 
yarn run v0.19.1
$ tsc 
✨  Done in 3.03s.
```